### PR TITLE
Increment verified compatible version number to remove erroneous alerts on world load.

### DIFF
--- a/module.json
+++ b/module.json
@@ -29,6 +29,6 @@
    "id": "close-player-art",
    "compatibility": {
       "minimum": "10.0",
-      "verified": "10.286"
+      "verified": "11.315"
    }
 }


### PR DESCRIPTION
Increment verified compatible version number to remove erroneous alerts on world load.

I haven't confirmed that this is working with the latest version 12 release, so I've just incremented to the last stable version I've confirmed.